### PR TITLE
Update to @serverless/core 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@serverless/core": "^0.1.0",
+    "@serverless/core": "^1.0.0",
     "aws-sdk": "^2.483.0",
     "lodash": "^4.17.11"
   },


### PR DESCRIPTION
@bboure  Thanks for this project, I updated the dependency. Since `@serverless/core` is still experimental, I feel that it is not compatible with previous versions.